### PR TITLE
Added font weights to google font plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,8 +32,8 @@ module.exports = {
       resolve: `gatsby-plugin-google-fonts`,
       options: {
         fonts: [
-          `montserrat`,
-          `myriad pro`,
+            'Montserrat\:400,700,900',
+            'Myriad Pro\:400,700,900'
         ],
         display: 'swap'
       }


### PR DESCRIPTION
#Issue: Emboldened "Who should attend" on About page by adding font weights to the google fonts plugin